### PR TITLE
Upgrade printnanny-services to 0.29.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,9 +2746,9 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "printnanny-api-client"
-version = "0.107.3"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347cce51273e94f2b68d4e54bd6ec007a01a0f818affdbe8da3746449b8ed896"
+checksum = "61699cc86d58ebc82444c35702cbe2d948c58ff2eb7fed514a97b5fed73b29cc"
 dependencies = [
  "bytes",
  "clap",
@@ -2808,8 +2808,8 @@ dependencies = [
 
 [[package]]
 name = "printnanny-services"
-version = "0.27.3"
-source = "git+https://github.com/bitsy-ai/printnanny-cli.git#ae1b2c9859a16c3bc50678fa0be3eac444b48725"
+version = "0.29.0"
+source = "git+https://github.com/bitsy-ai/printnanny-cli.git#1b432a792b2d924f280ea8bd4c42894151c54cd7"
 dependencies = [
  "anyhow",
  "async-process",

--- a/printnanny-gst-config/Cargo.toml
+++ b/printnanny-gst-config/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/bitsy-ai/printnanny-gst-plugin-rs/"
 [dependencies]
 log = "0.4"
 clap = { version = "3", features = ["derive", "cargo", "env", "wrap_help"] }
-printnanny-services = { version = "0.27.3", package = "printnanny-services", git = "https://github.com/bitsy-ai/printnanny-cli.git"}
+printnanny-services = { version = "0.29.0", package = "printnanny-services", git = "https://github.com/bitsy-ai/printnanny-cli.git"}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"


### PR DESCRIPTION
Includes a breaking change to the way configuration directories are computed/read